### PR TITLE
Allow only one reaction per comment for any given user

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -113,7 +113,7 @@ public final class DataServlet extends HttpServlet {
         String name = (String) userInfoEntity.getProperty("name");
 
         // If the user opted to post the comment anonymously, make the name Anonymous.
-        String anonymous = getParameter(request, "anonymous", "off").orElse(null);
+        String anonymous = getParameter(request, "anonymous", "off").orElse("off");
         if (anonymous.equals("on")) {
             name = "Anonymous";
         }

--- a/portfolio/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
@@ -36,10 +36,12 @@ public class LoginStatusServlet extends HttpServlet {
 
         if (userService.isUserLoggedIn()) {
             Entity userInfoEntity = getUserInfoEntity();
-
-            String where = (String) userInfoEntity.getProperty("where");
-            // If there is nothing in the where filed, set it to contact.html by default.
-            if (where == null) {
+            
+            String where = "/contact.html";
+            try {
+                where = (String) userInfoEntity.getProperty("where");
+            } catch (Exception e) {
+                // If there is nothing in the where filed, set it to contact.html by default.
                 where = "/contact.html";
             }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/RegisterServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/RegisterServlet.java
@@ -24,6 +24,8 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
 
 @WebServlet("/register")
 public class RegisterServlet extends HttpServlet {
@@ -62,6 +64,14 @@ public class RegisterServlet extends HttpServlet {
         entity.setProperty("max", 10);
         // Set English as the default language
         entity.setProperty("language", "en");
+        // Set contact.html as the default location after registering
+        entity.setProperty("where", "/contact.html");
+        // Keeps track of the keys of comments that were unliked by the user.
+        List<Key> unliked = new ArrayList<Key>();
+        entity.setProperty("unliked", unliked);
+        // Keeps track of the keys of comments that were liked by the user.
+        List<Key> liked = new ArrayList<Key>();
+        entity.setProperty("liked", liked);
         datastore.put(entity);
 
         response.sendRedirect("/contact.html");


### PR DESCRIPTION
The proposed changes in this PR limit the number of thumbs up to one per comment for any given user. If the user has already liked a comment, pressing the thumbs up icon again will unlike it. The same applies to thumbs down. These changes required that I adjusted the datastore to keep track of the comments a user has liked and the comments a user has not liked. 