### PR TITLE
Set a limit of one reaction per user per comment

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -110,24 +110,15 @@ public final class Comment {
         }
     }
 
-    public void updateDatabase(Entity commentEntity) {
+    public void updateDatabase(Entity commentEntity, Transaction txn) {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        // Update properties that can be changed.
+        commentEntity.setProperty("thumbsup", this.thumbsup);
+        commentEntity.setProperty("thumbsdown", this.thumbsdown);
+        commentEntity.setProperty("popularity", this.popularity);
 
-        Transaction txn = datastore.beginTransaction();
-        try {
-            // Update properties that can be changed.
-            commentEntity.setProperty("thumbsup", this.thumbsup);
-            commentEntity.setProperty("thumbsdown", this.thumbsdown);
-            commentEntity.setProperty("popularity", this.popularity);
-
-            // Add the updated entity back in the datastore
-            datastore.put(txn, commentEntity);
-            txn.commit();
-        } finally {
-            if (txn.isActive()) {
-                txn.rollback();
-            }
-        }
+        // Add the updated entity back in the datastore
+        datastore.put(txn, commentEntity);
 
         return;
     }

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -14,28 +14,121 @@
 
 package com.google.sps.data;
 
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+import com.google.gson.Gson;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.sps.data.Comment;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.datastore.TransactionOptions;
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.Translation;
+
 /** A comment on my portfolio */
 public final class Comment {
 
-  private final long id;
-  private final String content;
-  private final long time;
-  private long thumbsup;
-  private long thumbsdown;
-  private long popularity;
-  private final String name;
-  private final String email;
-  private final String username;
+    private final long id;
+    private String content;
+    private final long time;
+    private long thumbsup;
+    private long thumbsdown;
+    private long popularity;
+    private final String name;
+    private final String email;
+    private final String username;
 
-  public Comment(long id, String content, long time, long thumbsup, long thumbsdown, String name, String email, String username) {
-    this.id = id;
-    this.content = content;
-    this.time = time;
-    this.thumbsup = thumbsup;
-    this.thumbsdown = thumbsdown;
-    this.popularity = thumbsup - thumbsdown;
-    this.name = name;
-    this.email = email;
-    this.username = username;
-  }
+    public Comment(Entity commentEntity) {
+        this.id = (long) commentEntity.getKey().getId();
+        this.content = (String) commentEntity.getProperty("content");
+        this.time = (long) commentEntity.getProperty("time");
+        this.thumbsup = (long) commentEntity.getProperty("thumbsup");
+        this.thumbsdown = (long) commentEntity.getProperty("thumbsdown");
+        this.popularity = (long) commentEntity.getProperty("popularity");
+        this.name = (String) commentEntity.getProperty("name");
+        this.email = (String) commentEntity.getProperty("email");
+        this.username = (String) commentEntity.getProperty("username");
+    }
+
+     public void incrementThumbsup() {
+        this.thumbsup++;
+        return;
+    }
+
+    public void decrementThumbsup() {
+        this.thumbsup--;
+        return;
+    }
+
+    public void incrementThumbsdown() {
+        this.thumbsdown++;
+        return;
+    }
+
+    public void decrementThumbsdown() {
+        this.thumbsdown--;
+        return;
+    }
+
+    public void incrementPopularity() {
+        this.popularity++;
+        return;
+    }
+
+    public void decrementPopularity() {
+        this.popularity--;
+        return;
+    }
+
+    public void translateComment(String language) {
+        Translate translate = TranslateOptions.getDefaultInstance().getService();
+
+        try {
+            // Translate comment
+            Translation translation = translate.translate(this.content, Translate.TranslateOption.targetLanguage(language));
+            this.content = translation.getTranslatedText();
+            return;
+        } catch (RuntimeException e) {
+            return;
+        }
+    }
+
+    public void updateDatabase(Entity commentEntity) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+        Transaction txn = datastore.beginTransaction();
+        try {
+            // Update properties that can be changed.
+            commentEntity.setProperty("thumbsup", this.thumbsup);
+            commentEntity.setProperty("thumbsdown", this.thumbsdown);
+            commentEntity.setProperty("popularity", this.popularity);
+
+            // Add the updated entity back in the datastore
+            datastore.put(txn, commentEntity);
+            txn.commit();
+        } finally {
+            if (txn.isActive()) {
+                txn.rollback();
+            }
+        }
+
+        return;
+    }
 }

--- a/portfolio/src/main/java/com/google/sps/data/UserInfo.java
+++ b/portfolio/src/main/java/com/google/sps/data/UserInfo.java
@@ -104,24 +104,16 @@ public final class UserInfo {
         return unliked != null && unliked.contains(commentKey);
     }
 
-    public void updateDatabase(Entity userInfoEntity) {
+    public void updateDatabase(Entity userInfoEntity, Transaction txn) {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-        Transaction txn = datastore.beginTransaction();
-        try {
-            // Update properties that can be changed.
-            userInfoEntity.setProperty("unliked", this.unliked);
-            userInfoEntity.setProperty("liked", this.liked);
+        // Update properties that can be changed.
+        userInfoEntity.setProperty("unliked", this.unliked);
+        userInfoEntity.setProperty("liked", this.liked);
 
-            // Add the updated entity back in the datastore
-            datastore.put(txn, userInfoEntity);
-            txn.commit();
-        } finally {
-            if (txn.isActive()) {
-                txn.rollback();
-            }
-        }
-
+        // Add the updated entity back in the datastore
+        datastore.put(txn, userInfoEntity);
+        
         return;
     }
 }

--- a/portfolio/src/main/java/com/google/sps/data/UserInfo.java
+++ b/portfolio/src/main/java/com/google/sps/data/UserInfo.java
@@ -14,24 +14,114 @@
 
 package com.google.sps.data;
 
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+import com.google.gson.Gson;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.sps.data.Comment;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.datastore.TransactionOptions;
+
 /** User Info for each registered user */
 public final class UserInfo {
 
-  private long id;
-  private long max;
-  private long page;
-  private String name;
-  private String username;
-  private String filter;
-  private String searchBy;
+    private long id;
+    private long max;
+    private long page;
+    private final String name;
+    private final String username;
+    private String filter;
+    private String searchBy;
+    private List<Key> liked;
+    private List<Key> unliked;
 
-  public UserInfo(long id, long max, long page, String name, String username, String filter, String searchBy) {
-    this.id = id;
-    this.max = max;
-    this.page = page;
-    this.name = name;
-    this.username = username;
-    this.filter = filter;
-    this.searchBy = searchBy;
-  }
+    public UserInfo(Entity userInfoEntity) {
+        this.id = (long) userInfoEntity.getKey().getId();
+        this.max = (long) userInfoEntity.getProperty("max");
+        this.page = (long) userInfoEntity.getProperty("page");
+        this.name = (String) userInfoEntity.getProperty("name");
+        this.username = (String) userInfoEntity.getProperty("username");
+        this.filter = (String) userInfoEntity.getProperty("filter");
+        this.searchBy = (String) userInfoEntity.getProperty("searchBy");
+        this.liked = (List<Key>) userInfoEntity.getProperty("liked");
+        this.unliked = (List<Key>) userInfoEntity.getProperty("unliked");
+    }
+
+    public void addToLikedComments(Entity commentEntity) {
+        if (this.liked == null) {
+            this.liked =  new ArrayList<Key>();
+        }
+
+        this.liked.add(commentEntity.getKey());
+        return;
+    }
+
+    public void removeFromLikedComments(Entity commentEntity) {
+        this.liked.remove(commentEntity.getKey());
+        return;
+    }
+
+    public boolean isLikedComment(Entity commentEntity) {
+        Key commentKey = commentEntity.getKey();
+
+        return liked != null && liked.contains(commentKey);
+    }
+
+    public void addToUnlikedComments(Entity commentEntity) {
+        if (this.unliked == null) {
+            this.unliked =  new ArrayList<Key>();
+        }
+
+        this.unliked.add(commentEntity.getKey());
+        return;
+    }
+
+    public void removeFromUnlikedComments(Entity commentEntity) {
+        this.unliked.remove(commentEntity.getKey());
+        return;
+    }
+
+    public boolean isUnlikedComment(Entity commentEntity) {
+        Key commentKey = commentEntity.getKey();
+
+        return unliked != null && unliked.contains(commentKey);
+    }
+
+    public void updateDatabase(Entity userInfoEntity) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+        Transaction txn = datastore.beginTransaction();
+        try {
+            // Update properties that can be changed.
+            userInfoEntity.setProperty("unliked", this.unliked);
+            userInfoEntity.setProperty("liked", this.liked);
+
+            // Add the updated entity back in the datastore
+            datastore.put(txn, userInfoEntity);
+            txn.commit();
+        } finally {
+            if (txn.isActive()) {
+                txn.rollback();
+            }
+        }
+
+        return;
+    }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -113,7 +113,7 @@ public final class DataServlet extends HttpServlet {
         String name = (String) userInfoEntity.getProperty("name");
 
         // If the user opted to post the comment anonymously, make the name Anonymous.
-        String anonymous = getParameter(request, "anonymous", "off").orElse(null);
+        String anonymous = getParameter(request, "anonymous", "off").orElse("off");
         if (anonymous.equals("on")) {
             name = "Anonymous";
         }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -158,8 +158,6 @@ public final class DataServlet extends HttpServlet {
         List<Comment> comments = new ArrayList<>();
         Iterator<Entity> iter = results.asIterator();
 
-        Translate translate = TranslateOptions.getDefaultInstance().getService();
-
         // Iterates over the results until the results are less than the limit on comments or until the end of all results.
         for (int count = 0; count < (maxComments * page) && count < totalComments; count++) {
             if (iter.hasNext()) {
@@ -167,25 +165,10 @@ public final class DataServlet extends HttpServlet {
 
                 // Only add comment when it is part of the page the user is currently in.
                 if (count >= (maxComments * (page - 1))) {
-                    long id = entity.getKey().getId();
-                    String content = (String) entity.getProperty("content");
-                    long time = (long) entity.getProperty("time");
-                    long thumbsup = (long) entity.getProperty("thumbsup");
-                    long thumbsdown = (long) entity.getProperty("thumbsdown");
-                    String name = (String) entity.getProperty("name");
-                    String email = (String) entity.getProperty("email");
-                    String username = (String) entity.getProperty("username");
+                    Comment comment = new Comment(entity);
 
-                    String translatedComment = null;
-                    try {
-                        // Translate comment
-                        Translation translation = translate.translate(content, Translate.TranslateOption.targetLanguage(language));
-                        translatedComment = translation.getTranslatedText();
-                    } catch (Exception e) {
-                        translatedComment = content;
-                    }
+                    comment.translateComment(language);
 
-                    Comment comment = new Comment(id, translatedComment, time, thumbsup, thumbsdown, name, email, username);
                     comments.add(comment);
                 }
             }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -160,32 +160,10 @@ public final class DataServlet extends HttpServlet {
 
                 // Only add comment when it is part of the page the user is currently in.
                 if (count >= (maxComments * (page - 1))) {
-<<<<<<< HEAD
                     Comment comment = new Comment(entity);
 
                     comment.translateComment(language);
 
-=======
-                    long id = entity.getKey().getId();
-                    String content = (String) entity.getProperty("content");
-                    long time = (long) entity.getProperty("time");
-                    long thumbsup = (long) entity.getProperty("thumbsup");
-                    long thumbsdown = (long) entity.getProperty("thumbsdown");
-                    String name = (String) entity.getProperty("name");
-                    String email = (String) entity.getProperty("email");
-                    String username = (String) entity.getProperty("username");
-
-                    String translatedComment = null;
-                    try {
-                        // Translate comment
-                        Translation translation = translate.translate(content, Translate.TranslateOption.targetLanguage(language));
-                        translatedComment = translation.getTranslatedText();
-                    } catch (RuntimeException e) {
-                        translatedComment = content;
-                    }
-
-                    Comment comment = new Comment(id, translatedComment, time, thumbsup, thumbsdown, name, email, username);
->>>>>>> 45c9485a2c09cfb25dcb0f5762e4f9618c72c73e
                     comments.add(comment);
                 }
             }

--- a/portfolio/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
@@ -36,10 +36,12 @@ public class LoginStatusServlet extends HttpServlet {
 
         if (userService.isUserLoggedIn()) {
             Entity userInfoEntity = getUserInfoEntity();
-
-            String where = (String) userInfoEntity.getProperty("where");
-            // If there is nothing in the where filed, set it to contact.html by default.
-            if (where == null) {
+            
+            String where = "/contact.html";
+            try {
+                where = (String) userInfoEntity.getProperty("where");
+            } catch (Exception e) {
+                // If there is nothing in the where filed, set it to contact.html by default.
                 where = "/contact.html";
             }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/RegisterServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/RegisterServlet.java
@@ -24,6 +24,8 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
 
 @WebServlet("/register")
 public class RegisterServlet extends HttpServlet {
@@ -62,6 +64,14 @@ public class RegisterServlet extends HttpServlet {
         entity.setProperty("max", 10);
         // Set English as the default language
         entity.setProperty("language", "en");
+        // Set contact.html as the default location after registering
+        entity.setProperty("where", "/contact.html");
+        // Keeps track of the keys of comments that were unliked by the user.
+        List<Key> unliked = new ArrayList<Key>();
+        entity.setProperty("unliked", unliked);
+        // Keeps track of the keys of comments that were liked by the user.
+        List<Key> liked = new ArrayList<Key>();
+        entity.setProperty("liked", liked);
         datastore.put(entity);
 
         response.sendRedirect("/contact.html");

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -60,7 +60,7 @@ public final class ThumbsDownServlet extends HttpServlet {
             return;
         }
 
-        if (!unlikedComment(userInfoEntity, commentEntity)) {
+        if (!isUnlikedComment(userInfoEntity, commentEntity)) {
             changePopularity(commentEntity, 1);
             addToUnlikedComments(userInfoEntity, commentEntity);
         } else {
@@ -152,7 +152,7 @@ public final class ThumbsDownServlet extends HttpServlet {
         datastore.put(userInfoEntity);
     }
 
-    private boolean unlikedComment(Entity userInfoEntity, Entity commentEntity) {
+    private boolean isUnlikedComment(Entity userInfoEntity, Entity commentEntity) {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         List<Key> unliked = (ArrayList<Key>) userInfoEntity.getProperty("unliked");
         Key commentKey = commentEntity.getKey();

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -60,12 +60,12 @@ public final class ThumbsDownServlet extends HttpServlet {
             return;
         }
 
-        if (!isUnlikedComment(userInfoEntity, commentEntity)) {
-            decrementPopularity(commentEntity);
-            addToUnlikedComments(userInfoEntity, commentEntity);
-        } else {
+        if (isUnlikedComment(userInfoEntity, commentEntity)) {
             incrementPopularity(commentEntity);
             removeFromUnlikedComments(userInfoEntity, commentEntity);
+        } else {
+            decrementPopularity(commentEntity);
+            addToUnlikedComments(userInfoEntity, commentEntity);
         }
 
 

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -145,7 +145,7 @@ public final class ThumbsDownServlet extends HttpServlet {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Filter queryFilter = new FilterPredicate("id", Query.FilterOperator.EQUAL, id);
         Query query = new Query("UserInfo").setFilter(queryFilter);
-        
+
         return datastore.prepare(query).asSingleEntity();
     }
 
@@ -176,14 +176,6 @@ public final class ThumbsDownServlet extends HttpServlet {
         List<Key> unliked = (ArrayList<Key>) userInfoEntity.getProperty("unliked");
         Key commentKey = commentEntity.getKey();
 
-        if (unliked != null) {
-            if (unliked.contains(commentKey)) {
-                return true;
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
+        return unliked != null && unliked.contains(commentKey);
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -61,10 +61,10 @@ public final class ThumbsDownServlet extends HttpServlet {
         }
 
         if (!isUnlikedComment(userInfoEntity, commentEntity)) {
-            changePopularity(commentEntity, 1);
+            decrementPopularity(commentEntity);
             addToUnlikedComments(userInfoEntity, commentEntity);
         } else {
-            changePopularity(commentEntity, -1);
+            incrementPopularity(commentEntity);
             removeFromUnlikedComments(userInfoEntity, commentEntity);
         }
 
@@ -96,7 +96,7 @@ public final class ThumbsDownServlet extends HttpServlet {
         return commentEntity;
     }
 
-    private void changePopularity(Entity commentEntity, long value) {
+    private void decrementPopularity(Entity commentEntity) {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
@@ -105,8 +105,29 @@ public final class ThumbsDownServlet extends HttpServlet {
         // Get the previous popularity value.
         long prevPopularity = (long) commentEntity.getProperty("popularity");
 
-        long newThumbsDown = prevThumbsDown + value;
-        long newPopularity = prevPopularity - value;
+        long newThumbsDown = prevThumbsDown + 1;
+        long newPopularity = prevPopularity - 1;
+        
+        // Update the thumbs down property to be the previous value plus one.
+        commentEntity.setProperty("thumbsdown", newThumbsDown);
+        // Update the popularity property to be the previous one minus one.
+        commentEntity.setProperty("popularity", newPopularity);
+
+        // Add the updated entity back in the datastore
+        datastore.put(commentEntity);
+    }
+
+    private void incrementPopularity(Entity commentEntity) {
+        // Instantiate datastore
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+        // Get the previous thumbs down value.
+        long prevThumbsDown = (long) commentEntity.getProperty("thumbsdown");
+        // Get the previous popularity value.
+        long prevPopularity = (long) commentEntity.getProperty("popularity");
+
+        long newThumbsDown = prevThumbsDown - 1;
+        long newPopularity = prevPopularity + 1;
         
         // Update the thumbs down property to be the previous value plus one.
         commentEntity.setProperty("thumbsdown", newThumbsDown);

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -31,6 +31,11 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 
 @WebServlet("/thumbsdown-data")
 public final class ThumbsDownServlet extends HttpServlet {

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -36,6 +36,8 @@ import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.datastore.TransactionOptions;
 
 @WebServlet("/thumbsdown-data")
 public final class ThumbsDownServlet extends HttpServlet {
@@ -100,42 +102,58 @@ public final class ThumbsDownServlet extends HttpServlet {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-        // Get the previous thumbs down value.
-        long prevThumbsDown = (long) commentEntity.getProperty("thumbsdown");
-        // Get the previous popularity value.
-        long prevPopularity = (long) commentEntity.getProperty("popularity");
+        Transaction txn = datastore.beginTransaction();
+        try {
+            // Get the previous thumbs down value.
+            long prevThumbsDown = (long) commentEntity.getProperty("thumbsdown");
+            // Get the previous popularity value.
+            long prevPopularity = (long) commentEntity.getProperty("popularity");
 
-        long newThumbsDown = prevThumbsDown + 1;
-        long newPopularity = prevPopularity - 1;
-        
-        // Update the thumbs down property to be the previous value plus one.
-        commentEntity.setProperty("thumbsdown", newThumbsDown);
-        // Update the popularity property to be the previous one minus one.
-        commentEntity.setProperty("popularity", newPopularity);
+            long newThumbsDown = prevThumbsDown + 1;
+            long newPopularity = prevPopularity - 1;
+            
+            // Update the thumbs down property to be the previous value plus one.
+            commentEntity.setProperty("thumbsdown", newThumbsDown);
+            // Update the popularity property to be the previous one minus one.
+            commentEntity.setProperty("popularity", newPopularity);
 
-        // Add the updated entity back in the datastore
-        datastore.put(commentEntity);
+            // Add the updated entity back in the datastore
+            datastore.put(commentEntity);
+            txn.commit();
+        } finally {
+            if (txn.isActive()) {
+                txn.rollback();
+            }
+        }
     }
 
     private void incrementPopularity(Entity commentEntity) {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-        // Get the previous thumbs down value.
-        long prevThumbsDown = (long) commentEntity.getProperty("thumbsdown");
-        // Get the previous popularity value.
-        long prevPopularity = (long) commentEntity.getProperty("popularity");
+        Transaction txn = datastore.beginTransaction();
+        try {
+            // Get the previous thumbs down value.
+            long prevThumbsDown = (long) commentEntity.getProperty("thumbsdown");
+            // Get the previous popularity value.
+            long prevPopularity = (long) commentEntity.getProperty("popularity");
 
-        long newThumbsDown = prevThumbsDown - 1;
-        long newPopularity = prevPopularity + 1;
-        
-        // Update the thumbs down property to be the previous value plus one.
-        commentEntity.setProperty("thumbsdown", newThumbsDown);
-        // Update the popularity property to be the previous one minus one.
-        commentEntity.setProperty("popularity", newPopularity);
+            long newThumbsDown = prevThumbsDown - 1;
+            long newPopularity = prevPopularity + 1;
+            
+            // Update the thumbs down property to be the previous value plus one.
+            commentEntity.setProperty("thumbsdown", newThumbsDown);
+            // Update the popularity property to be the previous one minus one.
+            commentEntity.setProperty("popularity", newPopularity);
 
-        // Add the updated entity back in the datastore
-        datastore.put(commentEntity);
+            // Add the updated entity back in the datastore
+            datastore.put(commentEntity);
+            txn.commit();
+        } finally {
+            if (txn.isActive()) {
+                txn.rollback();
+            }
+        }
     }
 
     // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -51,33 +51,45 @@ public final class ThumbsDownServlet extends HttpServlet {
             return;
         }
 
-        Entity userInfoEntity = getUserInfoEntity();
-        UserInfo userInfo = new UserInfo(userInfoEntity);
-        
-        // Get comment's id (which was passed as a parameter).
-        long id = Long.parseLong(request.getParameter("id"));
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-        Entity commentEntity = getCommentEntity(id);
-        if (commentEntity == null) {
-            response.setContentType("text/html;");
-            response.getWriter().println("Unable to get comment.");
-            return;
+        TransactionOptions options = TransactionOptions.Builder.withXG(true);
+        Transaction txn = datastore.beginTransaction(options);
+        try {
+            Entity userInfoEntity = getUserInfoEntity();
+            UserInfo userInfo = new UserInfo(userInfoEntity);
+            
+            // Get comment's id (which was passed as a parameter).
+            long id = Long.parseLong(request.getParameter("id"));
+
+            Entity commentEntity = getCommentEntity(id);
+            if (commentEntity == null) {
+                response.setContentType("text/html;");
+                response.getWriter().println("Unable to get comment.");
+                return;
+            }
+
+            Comment comment = new Comment(commentEntity);
+
+            if (userInfo.isUnlikedComment(commentEntity)) {
+                comment.decrementThumbsdown();
+                comment.incrementPopularity();
+                userInfo.removeFromUnlikedComments(commentEntity);
+            } else {
+                comment.incrementThumbsdown();
+                comment.decrementPopularity();
+                userInfo.addToUnlikedComments(commentEntity);
+            }
+
+            comment.updateDatabase(commentEntity, txn);
+            userInfo.updateDatabase(userInfoEntity, txn);
+
+            txn.commit();
+        } finally {
+            if (txn.isActive()) {
+                txn.rollback();
+            }
         }
-
-        Comment comment = new Comment(commentEntity);
-
-        if (userInfo.isUnlikedComment(commentEntity)) {
-            comment.decrementThumbsdown();
-            comment.incrementPopularity();
-            userInfo.removeFromUnlikedComments(commentEntity);
-        } else {
-            comment.incrementThumbsdown();
-            comment.decrementPopularity();
-            userInfo.addToUnlikedComments(commentEntity);
-        }
-
-        comment.updateDatabase(commentEntity);
-        userInfo.updateDatabase(userInfoEntity);
 
         response.sendRedirect("/contact.html");
         return;

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -63,10 +63,10 @@ public final class ThumbsDownServlet extends HttpServlet {
         }
 
         if (isUnlikedComment(userInfoEntity, commentEntity)) {
-            incrementPopularity(commentEntity);
+            incrementPopularity(id);
             removeFromUnlikedComments(userInfoEntity, commentEntity);
         } else {
-            decrementPopularity(commentEntity);
+            decrementPopularity(id);
             addToUnlikedComments(userInfoEntity, commentEntity);
         }
 
@@ -98,12 +98,14 @@ public final class ThumbsDownServlet extends HttpServlet {
         return commentEntity;
     }
 
-    private void decrementPopularity(Entity commentEntity) {
+    private void decrementPopularity(long id) {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         Transaction txn = datastore.beginTransaction();
         try {
+            Entity commentEntity = getCommentEntity(id);
+
             // Get the previous thumbs down value.
             long prevThumbsDown = (long) commentEntity.getProperty("thumbsdown");
             // Get the previous popularity value.
@@ -118,7 +120,7 @@ public final class ThumbsDownServlet extends HttpServlet {
             commentEntity.setProperty("popularity", newPopularity);
 
             // Add the updated entity back in the datastore
-            datastore.put(commentEntity);
+            datastore.put(txn, commentEntity);
             txn.commit();
         } finally {
             if (txn.isActive()) {
@@ -127,12 +129,14 @@ public final class ThumbsDownServlet extends HttpServlet {
         }
     }
 
-    private void incrementPopularity(Entity commentEntity) {
+    private void incrementPopularity(long id) {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         Transaction txn = datastore.beginTransaction();
         try {
+            Entity commentEntity = getCommentEntity(id);
+
             // Get the previous thumbs down value.
             long prevThumbsDown = (long) commentEntity.getProperty("thumbsdown");
             // Get the previous popularity value.
@@ -147,7 +151,7 @@ public final class ThumbsDownServlet extends HttpServlet {
             commentEntity.setProperty("popularity", newPopularity);
 
             // Add the updated entity back in the datastore
-            datastore.put(commentEntity);
+            datastore.put(txn, commentEntity);
             txn.commit();
         } finally {
             if (txn.isActive()) {

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -145,10 +145,8 @@ public final class ThumbsDownServlet extends HttpServlet {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Filter queryFilter = new FilterPredicate("id", Query.FilterOperator.EQUAL, id);
         Query query = new Query("UserInfo").setFilter(queryFilter);
-        PreparedQuery results = datastore.prepare(query);
-        Entity userInfoEntity = results.asSingleEntity(); 
-
-        return userInfoEntity;
+        
+        return datastore.prepare(query).asSingleEntity();
     }
 
     private void addToUnlikedComments(Entity userInfoEntity, Entity commentEntity) {

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -41,39 +41,72 @@ import com.google.appengine.api.users.UserServiceFactory;
 public final class ThumbsDownServlet extends HttpServlet {
 
     @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {        
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        UserService userService = UserServiceFactory.getUserService();
+        if (!userService.isUserLoggedIn()) {
+            response.sendRedirect("/contact.html");
+            return;
+        }
+
+        Entity userInfoEntity = getUserInfoEntity();
+        
         // Get comment's id (which was passed as a parameter).
         long id = Long.parseLong(request.getParameter("id"));
+
+        Entity commentEntity = getCommentEntity(id);
+        if (commentEntity == null) {
+            response.setContentType("text/html;");
+            response.getWriter().println("Unable to get comment.");
+            return;
+        }
+
+        if (!unlikedComment(userInfoEntity, commentEntity)) {
+            changePopularity(commentEntity, 1);
+            addToUnlikedComments(userInfoEntity, commentEntity);
+        } else {
+            changePopularity(commentEntity, -1);
+            removeFromUnlikedComments(userInfoEntity, commentEntity);
+        }
+
+
+        response.sendRedirect("/contact.html");
+        return;
+    }
+
+    // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.
+    private Entity getCommentEntity(long id) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         // Using the id, get the comment's key.
         Key commentEntityKey;
         try {
             commentEntityKey = KeyFactory.createKey("Comment", id);
         } catch(Exception e) {
-            response.setContentType("text/html;");
-            response.getWriter().println("Unable to get comment's key.");
-            return;
+            return null;
         }
-
-        // Instantiate datastore
-        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         // Get the comment entity using its key.
         Entity commentEntity;
         try {
             commentEntity = datastore.get(commentEntityKey);
         } catch(Exception e) {
-            response.setContentType("text/html;");
-            response.getWriter().println("Unable to get comment.");
-            return;
+            return null;
         }
+
+        return commentEntity;
+    }
+
+    private void changePopularity(Entity commentEntity, long value) {
+        // Instantiate datastore
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         // Get the previous thumbs down value.
         long prevThumbsDown = (long) commentEntity.getProperty("thumbsdown");
         // Get the previous popularity value.
         long prevPopularity = (long) commentEntity.getProperty("popularity");
-        long newThumbsDown = prevThumbsDown + 1;
-        long newPopularity = prevPopularity - 1;
+
+        long newThumbsDown = prevThumbsDown + value;
+        long newPopularity = prevPopularity - value;
         
         // Update the thumbs down property to be the previous value plus one.
         commentEntity.setProperty("thumbsdown", newThumbsDown);
@@ -82,8 +115,56 @@ public final class ThumbsDownServlet extends HttpServlet {
 
         // Add the updated entity back in the datastore
         datastore.put(commentEntity);
+    }
 
-        response.sendRedirect("/contact.html");
-        return;
+    // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.
+    private Entity getUserInfoEntity() {
+        UserService userService = UserServiceFactory.getUserService();
+        String id = userService.getCurrentUser().getUserId();
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Filter queryFilter = new FilterPredicate("id", Query.FilterOperator.EQUAL, id);
+        Query query = new Query("UserInfo").setFilter(queryFilter);
+        PreparedQuery results = datastore.prepare(query);
+        Entity userInfoEntity = results.asSingleEntity(); 
+
+        return userInfoEntity;
+    }
+
+    private void addToUnlikedComments(Entity userInfoEntity, Entity commentEntity) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        List<Key> unliked = (ArrayList<Key>) userInfoEntity.getProperty("unliked");
+
+        if (unliked == null) {
+            unliked =  new ArrayList<Key>();
+        }
+
+        unliked.add(commentEntity.getKey());
+        userInfoEntity.setProperty("unliked", unliked);
+        datastore.put(userInfoEntity);
+    }
+
+    private void removeFromUnlikedComments(Entity userInfoEntity, Entity commentEntity) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        List<Key> unliked = (ArrayList<Key>) userInfoEntity.getProperty("unliked");
+
+        unliked.remove(commentEntity.getKey());
+        userInfoEntity.setProperty("unliked", unliked);
+        datastore.put(userInfoEntity);
+    }
+
+    private boolean unlikedComment(Entity userInfoEntity, Entity commentEntity) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        List<Key> unliked = (ArrayList<Key>) userInfoEntity.getProperty("unliked");
+        Key commentKey = commentEntity.getKey();
+
+        if (unliked != null) {
+            if (unliked.contains(commentKey)) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -62,14 +62,19 @@ public final class ThumbsUpServlet extends HttpServlet {
             return;
         }
 
+        Comment comment = new Comment(commentEntity);
+
         if (isLikedComment(userInfoEntity, commentEntity)) {
-            decrementPopularity(id);
+            comment.decrementThumbsup();
+            comment.decrementPopularity();
             removeFromLikedComments(userInfoEntity, commentEntity);
         } else {
-            incrementPopularity(id);
+            comment.incrementThumbsup();
+            comment.incrementPopularity();
             addToLikedComments(userInfoEntity, commentEntity);
         }
 
+        comment.updateDatabase(commentEntity);
 
         response.sendRedirect("/contact.html");
         return;
@@ -96,70 +101,6 @@ public final class ThumbsUpServlet extends HttpServlet {
         }
 
         return commentEntity;
-    }
-
-    private void decrementPopularity(long id) {
-        // Instantiate datastore
-        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-
-        Transaction txn = datastore.beginTransaction();
-        try {
-            Entity commentEntity = getCommentEntity(id);
-
-            // Get the previous thumbs up value.
-            long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
-            // Get the previous popularity value.
-            long prevPopularity = (long) commentEntity.getProperty("popularity");
-            
-            long newThumbsUp = prevThumbsUp - 1;
-            long newPopularity = prevPopularity - 1;
-            
-            // Update the thumbs up property to be the previous value plus one.
-            commentEntity.setProperty("thumbsup", newThumbsUp);
-            // Update the popularity property to be the previous one plus one.
-            commentEntity.setProperty("popularity", newPopularity);
-
-            // Add the updated entity back in the datastore.
-            datastore.put(txn, commentEntity);
-
-            txn.commit();
-        } finally {
-            if (txn.isActive()) {
-                txn.rollback();
-            }
-        }
-    }
-
-    private void incrementPopularity(long id) {
-        // Instantiate datastore
-        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-
-        Transaction txn = datastore.beginTransaction();
-        try {
-            Entity commentEntity = getCommentEntity(id);
-
-            // Get the previous thumbs up value.
-            long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
-            // Get the previous popularity value.
-            long prevPopularity = (long) commentEntity.getProperty("popularity");
-            
-            long newThumbsUp = prevThumbsUp + 1;
-            long newPopularity = prevPopularity + 1;
-            
-            // Update the thumbs up property to be the previous value plus one.
-            commentEntity.setProperty("thumbsup", newThumbsUp);
-            // Update the popularity property to be the previous one plus one.
-            commentEntity.setProperty("popularity", newPopularity);
-
-            // Add the updated entity back in the datastore.
-            datastore.put(txn, commentEntity);
-
-            txn.commit();
-        } finally {
-            if (txn.isActive()) {
-                txn.rollback();
-            }
-        }
     }
 
     // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -145,7 +145,7 @@ public final class ThumbsUpServlet extends HttpServlet {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Filter queryFilter = new FilterPredicate("id", Query.FilterOperator.EQUAL, id);
         Query query = new Query("UserInfo").setFilter(queryFilter);
-        
+
         return datastore.prepare(query).asSingleEntity();
     }
 
@@ -176,14 +176,6 @@ public final class ThumbsUpServlet extends HttpServlet {
         List<Key> liked = (ArrayList<Key>) userInfoEntity.getProperty("liked");
         Key commentKey = commentEntity.getKey();
 
-        if (liked != null) {
-            if (liked.contains(commentKey)) {
-                return true;
-            } else {
-                return false;
-            }
-        } else {
-            return false;
-        }
+        return liked != null && liked.contains(commentKey);
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -60,7 +60,7 @@ public final class ThumbsUpServlet extends HttpServlet {
             return;
         }
 
-        if (!likedComment(userInfoEntity, commentEntity)) {
+        if (!isLikedComment(userInfoEntity, commentEntity)) {
             changePopularity(commentEntity, 1);
             addToLikedComments(userInfoEntity, commentEntity);
         } else {
@@ -152,7 +152,7 @@ public final class ThumbsUpServlet extends HttpServlet {
         datastore.put(userInfoEntity);
     }
 
-    private boolean likedComment(Entity userInfoEntity, Entity commentEntity) {
+    private boolean isLikedComment(Entity userInfoEntity, Entity commentEntity) {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         List<Key> liked = (ArrayList<Key>) userInfoEntity.getProperty("liked");
         Key commentKey = commentEntity.getKey();

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -31,54 +31,140 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Query.FilterOperator;
+import com.google.appengine.api.datastore.Query.Filter;
+import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 
 @WebServlet("/thumbsup-data")
 public final class ThumbsUpServlet extends HttpServlet {
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        UserService userService = UserServiceFactory.getUserService();
+        if (!userService.isUserLoggedIn()) {
+            response.sendRedirect("/contact.html");
+            return;
+        }
+
+        Entity userInfoEntity = getUserInfoEntity();
+
         // Get comment's id (which was passed as a parameter).
         long id = Long.parseLong(request.getParameter("id"));
+
+        Entity commentEntity = getCommentEntity(id);
+        if (commentEntity == null) {
+            response.setContentType("text/html;");
+            response.getWriter().println("Unable to get comment.");
+            return;
+        }
+
+        if (!likedComment(userInfoEntity, commentEntity)) {
+            changePopularity(commentEntity, 1);
+            addToLikedComments(userInfoEntity, commentEntity);
+        } else {
+            changePopularity(commentEntity, -1);
+            removeFromLikedComments(userInfoEntity, commentEntity);
+        }
+
+
+        response.sendRedirect("/contact.html");
+        return;
+    }
+
+    // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.
+    private Entity getCommentEntity(long id) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         // Using the id, get the comment's key.
         Key commentEntityKey;
         try {
             commentEntityKey = KeyFactory.createKey("Comment", id);
         } catch(Exception e) {
-            response.setContentType("text/html;");
-            response.getWriter().println("Unable to get comment's key.");
-            return;
+            return null;
         }
-
-        // Instantiate datastore.
-        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         // Get the comment entity using its key.
         Entity commentEntity;
         try {
             commentEntity = datastore.get(commentEntityKey);
         } catch(Exception e) {
-            response.setContentType("text/html;");
-            response.getWriter().println("Unable to get comment.");
-            return;
+            return null;
         }
+
+        return commentEntity;
+    }
+
+    private void changePopularity(Entity commentEntity, long value) {
+        // Instantiate datastore
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         // Get the previous thumbs up value.
         long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
         // Get the previous popularity value.
         long prevPopularity = (long) commentEntity.getProperty("popularity");
-        long newThumbsUp = prevThumbsUp + 1;
-        long newPopularity = prevPopularity + 1;
         
-        // Update the thumbs up property to be the previous value plus one
+        long newThumbsUp = prevThumbsUp + value;
+        long newPopularity = prevPopularity + value;
+        
+        // Update the thumbs up property to be the previous value plus one.
         commentEntity.setProperty("thumbsup", newThumbsUp);
         // Update the popularity property to be the previous one plus one.
         commentEntity.setProperty("popularity", newPopularity);
 
         // Add the updated entity back in the datastore.
         datastore.put(commentEntity);
+    }
 
-        response.sendRedirect("/contact.html");
-        return;
+    // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.
+    private Entity getUserInfoEntity() {
+        UserService userService = UserServiceFactory.getUserService();
+        String id = userService.getCurrentUser().getUserId();
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Filter queryFilter = new FilterPredicate("id", Query.FilterOperator.EQUAL, id);
+        Query query = new Query("UserInfo").setFilter(queryFilter);
+        PreparedQuery results = datastore.prepare(query); 
+        Entity userInfoEntity = results.asSingleEntity(); 
+
+        return userInfoEntity;
+    }
+
+    private void addToLikedComments(Entity userInfoEntity, Entity commentEntity) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        List<Key> liked = (ArrayList<Key>) userInfoEntity.getProperty("liked");
+
+        if (liked == null) {
+            liked =  new ArrayList<Key>();
+        }
+
+        liked.add(commentEntity.getKey());
+        userInfoEntity.setProperty("liked", liked);
+        datastore.put(userInfoEntity);
+    }
+
+    private void removeFromLikedComments(Entity userInfoEntity, Entity commentEntity) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        List<Key> liked = (ArrayList<Key>) userInfoEntity.getProperty("liked");
+
+        liked.remove(commentEntity.getKey());
+        userInfoEntity.setProperty("liked", liked);
+        datastore.put(userInfoEntity);
+    }
+
+    private boolean likedComment(Entity userInfoEntity, Entity commentEntity) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        List<Key> liked = (ArrayList<Key>) userInfoEntity.getProperty("liked");
+        Key commentKey = commentEntity.getKey();
+
+        if (liked != null) {
+            if (liked.contains(commentKey)) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
     }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -26,6 +26,7 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.sps.data.Comment;
+import com.google.sps.data.UserInfo;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
@@ -51,6 +52,7 @@ public final class ThumbsUpServlet extends HttpServlet {
         }
 
         Entity userInfoEntity = getUserInfoEntity();
+        UserInfo userInfo = new UserInfo(userInfoEntity);
 
         // Get comment's id (which was passed as a parameter).
         long id = Long.parseLong(request.getParameter("id"));
@@ -64,17 +66,18 @@ public final class ThumbsUpServlet extends HttpServlet {
 
         Comment comment = new Comment(commentEntity);
 
-        if (isLikedComment(userInfoEntity, commentEntity)) {
+        if (userInfo.isLikedComment(commentEntity)) {
             comment.decrementThumbsup();
             comment.decrementPopularity();
-            removeFromLikedComments(userInfoEntity, commentEntity);
+            userInfo.removeFromLikedComments(commentEntity);
         } else {
             comment.incrementThumbsup();
             comment.incrementPopularity();
-            addToLikedComments(userInfoEntity, commentEntity);
+            userInfo.addToLikedComments(commentEntity);
         }
 
         comment.updateDatabase(commentEntity);
+        userInfo.updateDatabase(userInfoEntity);
 
         response.sendRedirect("/contact.html");
         return;

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -63,10 +63,10 @@ public final class ThumbsUpServlet extends HttpServlet {
         }
 
         if (isLikedComment(userInfoEntity, commentEntity)) {
-            decrementPopularity(commentEntity);
+            decrementPopularity(id);
             removeFromLikedComments(userInfoEntity, commentEntity);
         } else {
-            incrementPopularity(commentEntity);
+            incrementPopularity(id);
             addToLikedComments(userInfoEntity, commentEntity);
         }
 
@@ -98,12 +98,14 @@ public final class ThumbsUpServlet extends HttpServlet {
         return commentEntity;
     }
 
-    private void decrementPopularity(Entity commentEntity) {
+    private void decrementPopularity(long id) {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         Transaction txn = datastore.beginTransaction();
         try {
+            Entity commentEntity = getCommentEntity(id);
+
             // Get the previous thumbs up value.
             long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
             // Get the previous popularity value.
@@ -118,7 +120,7 @@ public final class ThumbsUpServlet extends HttpServlet {
             commentEntity.setProperty("popularity", newPopularity);
 
             // Add the updated entity back in the datastore.
-            datastore.put(commentEntity);
+            datastore.put(txn, commentEntity);
 
             txn.commit();
         } finally {
@@ -128,12 +130,14 @@ public final class ThumbsUpServlet extends HttpServlet {
         }
     }
 
-    private void incrementPopularity(Entity commentEntity) {
+    private void incrementPopularity(long id) {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
         Transaction txn = datastore.beginTransaction();
         try {
+            Entity commentEntity = getCommentEntity(id);
+
             // Get the previous thumbs up value.
             long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
             // Get the previous popularity value.
@@ -148,7 +152,7 @@ public final class ThumbsUpServlet extends HttpServlet {
             commentEntity.setProperty("popularity", newPopularity);
 
             // Add the updated entity back in the datastore.
-            datastore.put(commentEntity);
+            datastore.put(txn, commentEntity);
 
             txn.commit();
         } finally {

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -36,6 +36,8 @@ import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.datastore.Transaction;
+import com.google.appengine.api.datastore.TransactionOptions;
 
 @WebServlet("/thumbsup-data")
 public final class ThumbsUpServlet extends HttpServlet {
@@ -100,42 +102,60 @@ public final class ThumbsUpServlet extends HttpServlet {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-        // Get the previous thumbs up value.
-        long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
-        // Get the previous popularity value.
-        long prevPopularity = (long) commentEntity.getProperty("popularity");
-        
-        long newThumbsUp = prevThumbsUp - 1;
-        long newPopularity = prevPopularity - 1;
-        
-        // Update the thumbs up property to be the previous value plus one.
-        commentEntity.setProperty("thumbsup", newThumbsUp);
-        // Update the popularity property to be the previous one plus one.
-        commentEntity.setProperty("popularity", newPopularity);
+        Transaction txn = datastore.beginTransaction();
+        try {
+            // Get the previous thumbs up value.
+            long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
+            // Get the previous popularity value.
+            long prevPopularity = (long) commentEntity.getProperty("popularity");
+            
+            long newThumbsUp = prevThumbsUp - 1;
+            long newPopularity = prevPopularity - 1;
+            
+            // Update the thumbs up property to be the previous value plus one.
+            commentEntity.setProperty("thumbsup", newThumbsUp);
+            // Update the popularity property to be the previous one plus one.
+            commentEntity.setProperty("popularity", newPopularity);
 
-        // Add the updated entity back in the datastore.
-        datastore.put(commentEntity);
+            // Add the updated entity back in the datastore.
+            datastore.put(commentEntity);
+
+            txn.commit();
+        } finally {
+            if (txn.isActive()) {
+                txn.rollback();
+            }
+        }
     }
 
     private void incrementPopularity(Entity commentEntity) {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-        // Get the previous thumbs up value.
-        long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
-        // Get the previous popularity value.
-        long prevPopularity = (long) commentEntity.getProperty("popularity");
-        
-        long newThumbsUp = prevThumbsUp + 1;
-        long newPopularity = prevPopularity + 1;
-        
-        // Update the thumbs up property to be the previous value plus one.
-        commentEntity.setProperty("thumbsup", newThumbsUp);
-        // Update the popularity property to be the previous one plus one.
-        commentEntity.setProperty("popularity", newPopularity);
+        Transaction txn = datastore.beginTransaction();
+        try {
+            // Get the previous thumbs up value.
+            long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
+            // Get the previous popularity value.
+            long prevPopularity = (long) commentEntity.getProperty("popularity");
+            
+            long newThumbsUp = prevThumbsUp + 1;
+            long newPopularity = prevPopularity + 1;
+            
+            // Update the thumbs up property to be the previous value plus one.
+            commentEntity.setProperty("thumbsup", newThumbsUp);
+            // Update the popularity property to be the previous one plus one.
+            commentEntity.setProperty("popularity", newPopularity);
 
-        // Add the updated entity back in the datastore.
-        datastore.put(commentEntity);
+            // Add the updated entity back in the datastore.
+            datastore.put(commentEntity);
+
+            txn.commit();
+        } finally {
+            if (txn.isActive()) {
+                txn.rollback();
+            }
+        }
     }
 
     // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -145,10 +145,8 @@ public final class ThumbsUpServlet extends HttpServlet {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Filter queryFilter = new FilterPredicate("id", Query.FilterOperator.EQUAL, id);
         Query query = new Query("UserInfo").setFilter(queryFilter);
-        PreparedQuery results = datastore.prepare(query); 
-        Entity userInfoEntity = results.asSingleEntity(); 
-
-        return userInfoEntity;
+        
+        return datastore.prepare(query).asSingleEntity();
     }
 
     private void addToLikedComments(Entity userInfoEntity, Entity commentEntity) {

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -61,10 +61,10 @@ public final class ThumbsUpServlet extends HttpServlet {
         }
 
         if (!isLikedComment(userInfoEntity, commentEntity)) {
-            changePopularity(commentEntity, 1);
+            incrementPopularity(commentEntity);
             addToLikedComments(userInfoEntity, commentEntity);
         } else {
-            changePopularity(commentEntity, -1);
+            decrementPopularity(commentEntity);
             removeFromLikedComments(userInfoEntity, commentEntity);
         }
 
@@ -96,7 +96,7 @@ public final class ThumbsUpServlet extends HttpServlet {
         return commentEntity;
     }
 
-    private void changePopularity(Entity commentEntity, long value) {
+    private void decrementPopularity(Entity commentEntity) {
         // Instantiate datastore
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
@@ -105,8 +105,29 @@ public final class ThumbsUpServlet extends HttpServlet {
         // Get the previous popularity value.
         long prevPopularity = (long) commentEntity.getProperty("popularity");
         
-        long newThumbsUp = prevThumbsUp + value;
-        long newPopularity = prevPopularity + value;
+        long newThumbsUp = prevThumbsUp - 1;
+        long newPopularity = prevPopularity - 1;
+        
+        // Update the thumbs up property to be the previous value plus one.
+        commentEntity.setProperty("thumbsup", newThumbsUp);
+        // Update the popularity property to be the previous one plus one.
+        commentEntity.setProperty("popularity", newPopularity);
+
+        // Add the updated entity back in the datastore.
+        datastore.put(commentEntity);
+    }
+
+    private void incrementPopularity(Entity commentEntity) {
+        // Instantiate datastore
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+
+        // Get the previous thumbs up value.
+        long prevThumbsUp = (long) commentEntity.getProperty("thumbsup");
+        // Get the previous popularity value.
+        long prevPopularity = (long) commentEntity.getProperty("popularity");
+        
+        long newThumbsUp = prevThumbsUp + 1;
+        long newPopularity = prevPopularity + 1;
         
         // Update the thumbs up property to be the previous value plus one.
         commentEntity.setProperty("thumbsup", newThumbsUp);

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -60,12 +60,12 @@ public final class ThumbsUpServlet extends HttpServlet {
             return;
         }
 
-        if (!isLikedComment(userInfoEntity, commentEntity)) {
-            incrementPopularity(commentEntity);
-            addToLikedComments(userInfoEntity, commentEntity);
-        } else {
+        if (isLikedComment(userInfoEntity, commentEntity)) {
             decrementPopularity(commentEntity);
             removeFromLikedComments(userInfoEntity, commentEntity);
+        } else {
+            incrementPopularity(commentEntity);
+            addToLikedComments(userInfoEntity, commentEntity);
         }
 
 


### PR DESCRIPTION
The proposed changes in this PR limit the number of thumbs up to one per comment for any given user. If the user has already liked a comment, pressing the thumbs up icon again will unlike it. The same applies to thumbs down. These changes required that I adjusted the datastore to keep track of the comments a user has liked and the comments a user has not liked.

Fixing the default value for anonymous when null and fixing the error handling when getting the where field in the login status servlet were two bugs that I found when making these changes that is why I have inserted their fixes here.