### PR TITLE
Fix the language select dropdown

### DIFF
--- a/portfolio/src/main/webapp/contact.html
+++ b/portfolio/src/main/webapp/contact.html
@@ -140,6 +140,7 @@
                 <label for="translate-comments" class="col-sm-2 col-form-label">Language:</label>
                 <div class="col-sm-2">
                     <select class="custom-select form-control" name="translate-comments" id="translate-comments" onchange="this.form.submit()">
+                        <option value="">select</option>
                         <option value="af">Afrikaans</option>
                         <option value="ar">Arabic</option>
                         <option value="hy">Armenian</option>
@@ -148,7 +149,7 @@
                         <option value="cs">Czech</option>
                         <option value="da">Danish</option>
                         <option value="nl">Dutch</option>
-                        <option value="en" selected>English</option>
+                        <option value="en">English</option>
                         <option value="fi">Finnish</option>
                         <option value="fr">French</option>
                         <option value="ka">Georgian</option>


### PR DESCRIPTION
The change proposed in this pull request updates the select language dropdown so that there is a default "select" message with no value. It also fixes the problem of English always been selected in the dropdown.