### PR TITLE
Display delete button only to comments posted by the user

### DIFF
--- a/portfolio/src/main/webapp/contact.js
+++ b/portfolio/src/main/webapp/contact.js
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 function getComments() {
+    // Get the username of the user who is currently logged in. Null if the user is not logged in.
+    var username = null;
+    fetch("/login-status").then(response => response.json()).then((loginInfo) => {
+        username = loginInfo.username;
+    });
+
     fetch('/data').then(response => response.json()).then((comments) => {
         comments.forEach((comment) => {
             document.getElementById('comments-list').appendChild(createCommentBox(comment));

--- a/portfolio/src/main/webapp/contact.js
+++ b/portfolio/src/main/webapp/contact.js
@@ -19,9 +19,10 @@ function getComments() {
         username = loginInfo.username;
     });
 
+    // Display the comments
     fetch('/data').then(response => response.json()).then((comments) => {
         comments.forEach((comment) => {
-            document.getElementById('comments-list').appendChild(createCommentBox(comment));
+            document.getElementById('comments-list').appendChild(createCommentBox(comment, username));
         })
     });
 }

--- a/portfolio/src/main/webapp/contact.js
+++ b/portfolio/src/main/webapp/contact.js
@@ -98,7 +98,7 @@ function createCommentBox(comment, username) {
 
     const deleteButtonElement = document.createElement('button');
     deleteButtonElement.innerText = 'Delete';
-    reactionsLineElement.style.textAlign = 'right';
+    deleteButtonElement.style.textAlign = 'right';
     deleteButtonElement.className = 'btn btn-default btn-lg';
     deleteButtonElement.addEventListener('click', () => {
         deleteComment(comment);
@@ -109,7 +109,11 @@ function createCommentBox(comment, username) {
         location.reload();
     });
 
-    
+    // Hide delete box if the comment was not posted by the currently logged in user.
+    if (comment.username != username) {
+        deleteButtonElement.style.display = 'none';
+    }
+
     const buttonLineElement = document.createElement('div');
     buttonLineElement.className = 'd-flex w-100 justify-content-between';
     buttonLineElement.appendChild(deleteButtonElement);

--- a/portfolio/src/main/webapp/contact.js
+++ b/portfolio/src/main/webapp/contact.js
@@ -27,7 +27,7 @@ function getComments() {
     });
 }
 
-function createCommentBox(comment) {
+function createCommentBox(comment, username) {
     const commmentElement = document.createElement('li');
     commmentElement.className = 'list-group-item';
 


### PR DESCRIPTION
The changes proposed in this PR allow users to only delete the comments they have posted themselves. The delete button will be hidden for users who are not logged in or, if logged in, for the comments a user has not posted.