### PR TITLE
Remove getParameter and just use ofNullable and orElse

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -113,12 +113,12 @@ public final class DataServlet extends HttpServlet {
         String name = (String) userInfoEntity.getProperty("name");
 
         // If the user opted to post the comment anonymously, make the name Anonymous.
-        String anonymous = getParameter(request, "anonymous", "off").orElse(null);
+        String anonymous = Optional.ofNullable(request.getParameter("anonymous")).orElse("off");
         if (anonymous.equals("on")) {
             name = "Anonymous";
         }
         
-        String comment = getParameter(request, "user-comment", null).orElse(null);
+        String comment = Optional.ofNullable(request.getParameter("user-comment")).orElse("error");
 
         // Get current user's email.
         UserService userService = UserServiceFactory.getUserService();
@@ -133,12 +133,6 @@ public final class DataServlet extends HttpServlet {
 
         response.sendRedirect("/contact.html");
         return;
-    }
-
-    // Returns the desired parameter entered by the user, or null if the user input was invalid.
-    private Optional<String> getParameter(HttpServletRequest request, String name, String defaultValue) {
-        String value = request.getParameter(name);
-        return Optional.ofNullable(value);
     }
 
     // Iterates over a comments query and returns an array of comments.

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteServlet.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import com.google.gson.Gson;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -38,7 +39,7 @@ public final class DeleteServlet extends HttpServlet {
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        long id = Long.parseLong(request.getParameter("id"));
+        long id = Long.parseLong(Optional.ofNullable(request.getParameter("anonymous")).orElse("off"));
         Key commentEntityKey = KeyFactory.createKey("Comment", id);
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         datastore.delete(commentEntityKey);

--- a/portfolio/src/main/java/com/google/sps/servlets/FiltersServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/FiltersServlet.java
@@ -44,10 +44,10 @@ public final class FiltersServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Get the filter input from the form.
-        String filter = getParameter(request, "filter-comments", null).orElse(null);
+        String filter = Optional.ofNullable(request.getParameter("filter-comments")).orElse("recent");
 
         // Get the search by input from the form.
-        String searchBy = getParameter(request, "search-by", null).orElse(null);
+        String searchBy = Optional.ofNullable(request.getParameter("search-by")).orElse("name");
 
         Entity userInfoEntity = getUserInfoEntity();
 
@@ -61,12 +61,6 @@ public final class FiltersServlet extends HttpServlet {
 
         response.sendRedirect("/contact.html");
         return;
-    }
-
-    // Returns the desired parameter entered by the user, or null if the user input was invalid.
-    private Optional<String> getParameter(HttpServletRequest request, String name, String defaultValue) {
-        String value = request.getParameter(name);
-        return Optional.ofNullable(value);
     }
 
     // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.

--- a/portfolio/src/main/java/com/google/sps/servlets/LanguageServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LanguageServlet.java
@@ -44,7 +44,7 @@ public final class LanguageServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Get the language input from the form.
-        String language = getParameter(request, "translate-comments", null).orElse(null);
+        String language = Optional.ofNullable(request.getParameter("search-by")).orElse("en");
 
         Entity userInfoEntity = getUserInfoEntity();
 
@@ -56,12 +56,6 @@ public final class LanguageServlet extends HttpServlet {
 
         response.sendRedirect("/contact.html");
         return;
-    }
-
-    // Returns the desired parameter entered by the user, or null if the user input was invalid.
-    private Optional<String> getParameter(HttpServletRequest request, String name, String defaultValue) {
-        String value = request.getParameter(name);
-        return Optional.ofNullable(value);
     }
 
     // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.

--- a/portfolio/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
@@ -37,13 +37,19 @@ public class LoginStatusServlet extends HttpServlet {
         if (userService.isUserLoggedIn()) {
             Entity userInfoEntity = getUserInfoEntity();
 
-            String where = (String) userInfoEntity.getProperty("where");
-            // If there is nothing in the where filed, set it to contact.html by default.
-            if (where == null) {
+            String where;
+            try {
+                where = (String) userInfoEntity.getProperty("where");
+            } catch (NullPointerException e) {
                 where = "/contact.html";
             }
 
-            String logoutUrl = userService.createLogoutURL(where);
+            String logoutUrl;
+            try {
+                logoutUrl = userService.createLogoutURL(where);
+            } catch (NullPointerException e) {
+                logoutUrl = userService.createLogoutURL("/contact.html");
+            }
 
             String username = getUsername(userService.getCurrentUser().getUserId());
 

--- a/portfolio/src/main/java/com/google/sps/servlets/MaxCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/MaxCommentsServlet.java
@@ -44,7 +44,7 @@ public final class MaxCommentsServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Get the max-comments input from the form.
-        String max = getParameter(request, "max-comments", null).orElse(null);
+        String max = Optional.ofNullable(request.getParameter("max-comments")).orElse(null);
 
         // If a maximum number of comments has been selected, only update the maxComments variable and return.
         if (max != null) {
@@ -70,12 +70,6 @@ public final class MaxCommentsServlet extends HttpServlet {
 
         response.sendRedirect("/contact.html");
         return;
-    }
-
-    // Returns the desired parameter entered by the user, or null if the user input was invalid.
-    private Optional<String> getParameter(HttpServletRequest request, String name, String defaultValue) {
-        String value = request.getParameter(name);
-        return Optional.ofNullable(value);
     }
 
     // Accesses the datastore to get the UserInfo entity. Returns the entity or null if one does not exist.

--- a/portfolio/src/main/java/com/google/sps/servlets/PaginationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/PaginationServlet.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Iterator;
+import java.util.Optional;
 import com.google.gson.Gson;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -48,7 +49,12 @@ public final class PaginationServlet extends HttpServlet {
 
         // Prepare information to be passed as a json
         long total = (long) allCommentsEntity.getProperty("total");
-        long max = (long) userInfoEntity.getProperty("max");
+        long max;
+        try {
+            max = (long) userInfoEntity.getProperty("max");
+        } catch (NullPointerException e) {
+            max = 10;
+        }
         long page = (long) userInfoEntity.getProperty("page");
         String filter = (String) userInfoEntity.getProperty("filter");
         
@@ -63,7 +69,7 @@ public final class PaginationServlet extends HttpServlet {
         Entity userInfoEntity = getUserInfoEntity();
 
         // Update the page property of UserInfo.
-        long newPage = Long.parseLong(request.getParameter("i")) + 1;
+        long newPage = Long.parseLong(Optional.ofNullable(request.getParameter("i")).orElse(null)) + 1;
         userInfoEntity.setProperty("page", newPage);
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         datastore.put(userInfoEntity);

--- a/portfolio/src/main/java/com/google/sps/servlets/PaginationServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/PaginationServlet.java
@@ -48,15 +48,10 @@ public final class PaginationServlet extends HttpServlet {
         Entity userInfoEntity = getUserInfoEntity();
 
         // Prepare information to be passed as a json
-        long total = (long) allCommentsEntity.getProperty("total");
-        long max;
-        try {
-            max = (long) userInfoEntity.getProperty("max");
-        } catch (NullPointerException e) {
-            max = 10;
-        }
-        long page = (long) userInfoEntity.getProperty("page");
-        String filter = (String) userInfoEntity.getProperty("filter");
+        long total = (long) Optional.ofNullable(allCommentsEntity.getProperty("total")).orElse(0);
+        long max = (long) Optional.ofNullable(userInfoEntity.getProperty("max")).orElse(10);
+        long page = (long) Optional.ofNullable(userInfoEntity.getProperty("page")).orElse(1);
+        String filter = (String) Optional.ofNullable(userInfoEntity.getProperty("filter")).orElse("recent");
         
         // Convert to json.
         String json = "{\"total\": " + total + ", \"max\": " + max + ", \"page\": " + page + ", \"filter\": \"" + filter + "\"}";

--- a/portfolio/src/main/java/com/google/sps/servlets/RegisterServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/RegisterServlet.java
@@ -20,6 +20,7 @@ import com.google.appengine.api.users.UserServiceFactory;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import java.io.IOException;
+import java.util.Optional;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -36,14 +37,14 @@ public class RegisterServlet extends HttpServlet {
             return;
         }
 
-        String username = request.getParameter("user-username");
+        String username = Optional.ofNullable(request.getParameter("user-username")).orElse(null);
         // Ask for username again if the username chosen was not available.
         if (!usernameAvailable(username)) {
             response.sendRedirect("/contact.html");
             return;
         }
 
-        String name = request.getParameter("user-name");
+        String name = Optional.ofNullable(request.getParameter("user-name")).orElse(null);
 
         String id = userService.getCurrentUser().getUserId();
 

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsDownServlet.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import com.google.gson.Gson;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -38,7 +39,7 @@ public final class ThumbsDownServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {        
         // Get comment's id (which was passed as a parameter).
-        long id = Long.parseLong(request.getParameter("id"));
+        long id = Long.parseLong(Optional.ofNullable(request.getParameter("id")).orElse(null));
 
         // Using the id, get the comment's key.
         Key commentEntityKey;

--- a/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ThumbsUpServlet.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import com.google.gson.Gson;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -38,7 +39,7 @@ public final class ThumbsUpServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Get comment's id (which was passed as a parameter).
-        long id = Long.parseLong(request.getParameter("id"));
+        long id = Long.parseLong(Optional.ofNullable(request.getParameter("id")).orElse(null));
 
         // Using the id, get the comment's key.
         Key commentEntityKey;

--- a/portfolio/src/main/java/com/google/sps/servlets/WhereServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/WhereServlet.java
@@ -20,6 +20,7 @@ import com.google.appengine.api.users.UserServiceFactory;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import java.io.IOException;
+import java.util.Optional;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -37,7 +38,7 @@ public class WhereServlet extends HttpServlet {
             return;
         }
 
-        String newLocation = request.getParameter("newLocation");
+        String newLocation = Optional.ofNullable(request.getParameter("newLocation")).orElse("/index.html");
 
         Entity userInfoEntity = getUserInfoEntity();
 


### PR DESCRIPTION
The proposed changes to this PR get rid of the redundant getParameter function. Both the getParameter function and the version that used optional.ofnullable and orelse had the same default value. Now, all the requests to getParameter use ofnullable and the default value is inserted inside orelse.