### PR TITLE
Get rid of redundant reassignment to where inside try-catch block

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/LoginStatusServlet.java
@@ -40,9 +40,8 @@ public class LoginStatusServlet extends HttpServlet {
             String where = "/contact.html";
             try {
                 where = (String) userInfoEntity.getProperty("where");
-            } catch (NullPointerException e) {
+            } catch (NullPointerExcegption e) {
                 // If there is nothing in the where filed, set it to contact.html by default.
-                where = "/contact.html";
             }
 
             String logoutUrl;


### PR DESCRIPTION
The change proposed in this PR just gets rid of a redundant reassignment of where to contact.html that happened inside the catch block.